### PR TITLE
Replace proprietary Thunderforest tiles with Wikimedia tiles

### DIFF
--- a/ffmap/web/static/js/map.js
+++ b/ffmap/web/static/js/map.js
@@ -10,8 +10,8 @@ var tilesosmde = new L.TileLayer('https://{s}.osm.rrze.fau.de/osmde/{z}/{x}/{y}.
 	maxNativeZoom: 19,
 	maxZoom: 22
 });
-var tilestfod = new L.TileLayer('https://{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png', {
-	attribution: 'Maps &copy; <a href="http://www.thunderforest.com">Thunderforest</a>, Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+var tileswiki = new L.TileLayer('https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png', {
+	attribution: 'Maps &copy; <a href="https://foundation.wikimedia.org/wiki/Maps_Terms_of_Use">Wikimedia Maps</a>, Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
 	maxNativeZoom: 22,
 	maxZoom: 22
 });
@@ -34,7 +34,7 @@ var popuplayer = new L.TileLayer('');
 layersControl = new L.Control.Layers({
 	"openstreetmap.org": tilesosmorg,
 	"openstreetmap.de": tilesosmde,
-	"Thunderforest Outdoors": tilestfod
+	"Wikimedia": tileswiki
 }, {
 	"Routers V1": routers,
 	"Routers V2": routers_v2,
@@ -61,7 +61,7 @@ function update_permalink() {
 		var zoom = map.getZoom();
 		window.history.replaceState({}, document.title,
 			mapurl + '?mapcenter=' + pos.lat.toFixed(5) + ',' + pos.lng.toFixed(5) + ',' + zoom
-			+ '&source=' + (map.hasLayer(tilesosmorg) ? 1 : (map.hasLayer(tilesosmde) ? 2 : 3))
+			+ '&source=' + (map.hasLayer(tilesosmorg) ? 1 : (map.hasLayer(tilesosmde) ? 2 : (map.hasLayer(tileswiki) ? 4 : 1))
 			+ '&layers=' + (map.hasLayer(routers)|0) + ','
 			+ (map.hasLayer(routers_v2)|0) + ','
 			+ (map.hasLayer(routers_local)|0) + ','
@@ -84,7 +84,7 @@ function initialLayers() {
 function setupMap(getargs) {
 	var getsrc = getargs.replace("source=", "");
 	if(getsrc==2) { map.addLayer(tilesosmde); }
-	else if(getsrc==3) { map.addLayer(tilestfod); }
+	else if(getsrc==4) { map.addLayer(tileswiki); }
 	else { map.addLayer(tilesosmorg); }
 }
 function setupLayers(getargs) {


### PR DESCRIPTION
Thunderforest Maps are proprietary and require an api key.

As I quite like the Wikimedia map style as it has a very low
contrast which makes nodes and connections between them stand out
way more.

The map source parameter is updated as well, so old URLs fall back
to the default style.

Signed-off-by: Fabian Bläse <fabian@blaese.de>