### PR TITLE
Use RRZE servers instead of OSMs for default tiles

### DIFF
--- a/ffmap/web/static/js/map.js
+++ b/ffmap/web/static/js/map.js
@@ -1,6 +1,6 @@
 var map = L.map('map');
 
-var tilesosmorg = new L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+var tilesosmorg = new L.tileLayer('https://{s}.osm.rrze.fau.de/tiles/{z}/{x}/{y}.png', {
 	attribution: '<a href="https://www.openstreetmap.org/copyright">&copy; Openstreetmap Contributors</a>',
 	maxNativeZoom: 19,
 	maxZoom: 22


### PR DESCRIPTION
Openstreemaps tile servers do not support IPv6.
They are also quite slow sometimes.

Therefore the default tile source is changed to RRZE servers
which do support IPv6 and are way faster.

Signed-off-by: Fabian Bläse <fabian@blaese.de>