### PR TITLE
Hide Legacy Routers Layer by default

### DIFF
--- a/ffmap/web/static/js/map.js
+++ b/ffmap/web/static/js/map.js
@@ -77,7 +77,6 @@ function initialMap() {
 	map.addLayer(tilesosmorg);
 }
 function initialLayers() {
-	routers.addTo(map);
 	routers_v2.addTo(map);
 	routers_local.addTo(map);
 }


### PR DESCRIPTION
Every displayed Layer uses extra performance on both the Client and on the Server (additional tiles have to be rendered and served).
The "Routers" layers only shows old data, which is not updated anymore, so it can be hidden away and removed in a future commit.